### PR TITLE
feat(drawer): run tests against feature branch in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
 - 4.2
 script:
 - npm run ci
+- chmod 777 ./test/shell_scripts/run_tests.sh
+- ./test/shell_scripts/run_tests.sh
 after_success:
 - cat ./build/reports/coverage/coverage.lcov | node_modules/coveralls/bin/coveralls.js
 after_failure:
@@ -19,3 +21,6 @@ deploy:
   on:
     branch: master
     tags: true
+env:
+  global:
+    secure: ZSuh/+b0r75XvGRfl89QfI33u/u0Mg6b3hDGmqjWAuq2Zrs/JgTO26sH7EqedAYV4OGp3VLN+pkRoOvzXgyyz1Zf6O03rgBfjbcBxONBWmQKRjRiNEe2nbBvw97xgVw1VOqvbi19DoJJHwfjZS8fwv7gZh/2iRipQSsdgKv2Dj4wzvJwGKlVyUH2puKVz2gwTxv9eTk2c5QiI1Jex8kZl7acQVtOR50nud5g10s+QuILViAcqnd9bY0dn7bM9OKQ7deViAngD2a0Vgrhtx15vqeCpujLf+F2DM9gPpBR9mcPtU2UAUV9QZtfS8zhn4va8ZIYiDck4EnFC7bHbj4QtoOxt2At+XwcGgEQaLjAeTFsYSXgbOrJkKXF0yGhkcTvsQCg/D09i/LO/1OUNvq0wH4p+uMxIfD2fSUJrqdKewnDBlm4Oc5LxWyN95qT2CCNtLRPRBRM7nTnbSKcEG0gKHpN26zHwLU+dfmhAxqu2I9Nlsi3J84smOpA3gwQsF7BH18jPXJ9pA47gEmdl4Zp6oibga4whkDa9JH+SuzajbzBn5iJWQjiaJm4nTBwiXbjzAg6wYZaHQq7rPJeuLShmVL4cI1D4Iq/XHhVYm/IsXEH9xMDl0/awUq4wtFphRZaMjO0XGzXtSIKIjm5+jY/icgN2GTDo4w7ZeFj4ww6pks=

--- a/test/shell_scripts/run_tests.sh
+++ b/test/shell_scripts/run_tests.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+echo "Trigger the Selenium tests for master branch: ux-test-platform repo...."
+
+#Step 1: API to trigger the ux-test-platform build with the below config
+body="{
+\"request\": {
+\"message\": \"feat(drawer): Run Drawer Tests\",
+\"branch\":\"master\",
+\"config\": {
+\"script\": [
+\"export component=drawer\",
+\"export feature_branch=$TRAVIS_BRANCH\",
+\"chmod 777 ./src/main/shell_scripts/components.sh\",
+\"./src/main/shell_scripts/components.sh\",
+\"mvn -Dtest_suite_xml=drawer.xml test\"
+]
+}
+}}"
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Travis-API-Version: 3" \
+  -H "Authorization: token $AUTH_TOKEN" \
+  -d "$body" \
+  https://api.travis-ci.org/repo/Pearson-Higher-Ed%2Fux-test-platform/requests
+
+echo ""
+echo "Waiting for approximately 5s for the Selenium tests to trigger..."
+echo ""
+
+REPO_URI="https://api.travis-ci.org/repos/Pearson-Higher-Ed/ux-test-platform/builds"
+i=1
+max=20
+while [ $i -lt $max ]
+do
+  curl -i $REPO_URI > test.json #Push the json response to a temp file 'test.json'
+
+  LATEST_STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1 ) #Fetch the state of the last build
+  LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #Fetch the id of the last build
+  BRANCH=$(grep -o '"branch":.[a-z\"]*' test.json | head -1 ) #Fetch the branch name of the last build
+
+  get_state_value=${BRANCH#*:}
+  BRANCH="${get_state_value//\"}"
+
+  if [ $BRANCH == "master" ] #If condition to check if the last triggered build is master
+    sleep 5
+    curl -i $REPO_URI > test.json
+  then LATEST_ID=$(grep -o '"id":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #
+  echo "LATEST_ID of master branch.............................. $LATEST_ID"
+  export LATEST_ID
+    break
+  else
+    true $(( i++ ))
+    sleep 1
+  fi
+done
+
+#Step 2 : Fetch the build status of the 'master' branch
+get_buildId_value=${LATEST_ID#*:}
+BUILD_ID="${get_buildId_value//\"}"
+
+REPO_URI_WITH_BUILDID="$REPO_URI/$BUILD_ID"
+echo $REPO_URI_WITH_BUILDID
+
+i=1
+max=900 #Max time for the tests to run.
+while [ $i -lt $max ]
+do
+
+curl -i $REPO_URI_WITH_BUILDID > test.json
+
+STATE=$(grep -o '"state":.[a-z\"]*' test.json | head -1 ) #Fetch the state of master build
+#RESULT=$(grep -o '"result":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #For debug
+STATUS=$(grep -o '"status":.[0-9]*' test.json | head -1  | grep ':.[0-9]*') #Fetch the status of master build
+
+echo "--------------------------------------------"
+echo "Polling for the tests run build status..."
+echo "ux-test-platform build run in progress: https://travis-ci.org/Pearson-Higher-Ed/ux-test-platform/builds/$BUILD_ID"
+
+get_state_value=${STATE#*:}
+STATE="${get_state_value//\"}"
+
+get_status_value=${STATUS#*:}
+STATUS="${get_status_value//\"}"
+
+if [ $STATUS == "0" ] #Success condition
+then
+  echo "counter-> $i"
+  echo "TESTS RUN... PASSED :-) "
+  break #As soon as the tests run pass, we break and return back to the elements build run
+elif [ $STATUS == "1" ] #Failure condition
+then
+ echo "TESTS RUN... FAILED :-("
+ exit 1 #As soon as the tests run fail, we stop building elements
+elif [[ $STATE == "finished" && $STATUS == "n" ]] #Unexpected failure due to Travis environment issues
+then
+ echo "TESTS RUN... NULL :-("
+ exit 1 #For some reason, if the ux-test-platform build breaks or halts
+elif [ $i == "900" ] #Maxed out condition
+  then
+  echo "ux-test-platform run time has maxed out..."
+  exit 1 #Selenium tests run for more than the max time.
+fi
+
+true $(( i++ ))
+sleep 1 #This 1s is required to poll the build status for every second
+echo "counter-> $i"
+done


### PR DESCRIPTION
- Add more info to the Travis API that will trigger ux-test-platform's drawer test suite only.
- And export feature branch name to ux-test-platform, that way the tests point to feature_branch of drawer only.